### PR TITLE
Add various smaller tweaks to docs

### DIFF
--- a/docs/components/advanced.md
+++ b/docs/components/advanced.md
@@ -12,7 +12,7 @@ One good example of such a component is the [producers/ossf-scorecard component]
 
 In the below `Dockerfile` we using a custom base image and then are further configuring that.
 
-```text title="dracon/components/producers/ossf-scorecard/Dockerfile"
+```docker title="dracon/components/producers/ossf-scorecard/Dockerfile"
 ARG OSSF_SCORECARD_SAFETY_BASE_IMAGE
 FROM gcr.io/openssf/scorecard:stable
 
@@ -25,7 +25,7 @@ ENTRYPOINT ["/scorecard"]
 
 In addition, a `Makefile` is placed inside the component folder, to advice Smithy on how to build the component image.
 
-```bash title="dracon/components/producers/ossf-scorecard/Makefile"
+```makefile title="dracon/components/producers/ossf-scorecard/Makefile"
 .PHONY: component publish
 
 CONTAINER_REPO=

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,7 @@ as follows:
 helm upgrade \
   --install \
   --namespace dracon \
-  --version 0.15.0 \
+  --version 0.19.0 \
   dracon-oss-components \
   oci://ghcr.io/ocurity/dracon/charts/dracon-oss-components
 ```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -115,6 +115,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['bash', 'docker', 'makefile'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -39,7 +39,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/ocurity/docs/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/ocurity/docs/tree/main/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
This PR adds various smaller tweaks to the docs:

- [🐛 Fix edit link](https://github.com/ocurity/docs/commit/c1d8302a8cb7385952be9f0457d98aeca29fc199): Now the `edit on github` button should work
- [🐛 Fix version mismatch in quickstart](https://github.com/ocurity/docs/commit/7fb060efcf22ec13569a8a69431e445e3952824e): Forgot to update the version in a second place in the quickstart guide
- [✨ Add support for other languages in code-block](https://github.com/ocurity/docs/commit/8f2f2757d323bc302026360779af8f5e65b77f14): Added support for `docker, makefile, bash` syntax highlighting
- [🐛 Correctly use docker and makefile languages](https://github.com/ocurity/docs/commit/1ac96589984aefa2a52b57cc4f6deff528dbe53b): Now making use of these new languages from ^